### PR TITLE
feat: IT-23-Forget-user-password(Backend)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "jsonwebtoken": "^9.0.2",
         "mongoose": "^8.11.0",
         "morgan": "^1.10.0",
-        "nodemailer": "^6.10.0",
+        "nodemailer": "^6.10.1",
         "nodemon": "^3.1.9",
         "passport": "^0.7.0",
         "passport-google-oauth20": "^2.0.0",
@@ -6819,9 +6819,9 @@
       "dev": true
     },
     "node_modules/nodemailer": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.0.tgz",
-      "integrity": "sha512-SQ3wZCExjeSatLE/HBaXS5vqUOQk6GtBdIIKxiFdmm01mOQZX/POJkO3SUX1wDiYcwUOJwT23scFSC9fY2H8IA==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
       "engines": {
         "node": ">=6.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^8.11.0",
     "morgan": "^1.10.0",
-    "nodemailer": "^6.10.0",
+    "nodemailer": "^6.10.1",
     "nodemon": "^3.1.9",
     "passport": "^0.7.0",
     "passport-google-oauth20": "^2.0.0",

--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -1,22 +1,20 @@
-import { User, IUser } from "../models/User";
-import VerificationToken from "../models/VerificationToken";
-import { NextFunction, Request, Response } from "express";
-import { ErrorWithStatus } from "../middlewares/ErrorHandler";
-import { ClientErrorStatus } from "../utils/errorStatusCode";
+import { User, IUser } from '../models/User';
+import VerificationToken from '../models/VerificationToken';
+import { NextFunction, Request, Response } from 'express';
+import { ErrorWithStatus } from '../middlewares/ErrorHandler';
+import { ClientErrorStatus } from '../utils/errorStatusCode';
 
-import { authErrorMessages, ServeErrorMessage } from "../utils/errorMessages";
-import crypto from "crypto";
-import { sendVerificationEmail } from "../services/email.service";
-import authServices from "../services/auth.service";
-import { updateProfile } from "../services/user.service";
-import { authSuccessMessage } from "../utils/successMessage";
-import { userProfileMessage } from "../utils/userProfileMessage";
+import { authErrorMessages, ServeErrorMessage } from '../utils/errorMessages';
+import crypto from 'crypto';
+import { sendVerificationEmail } from '../services/email.service';
+import authServices from '../services/auth.service';
+import { updateProfile } from '../services/user.service';
+import { authSuccessMessage } from '../utils/successMessage';
+import { userProfileMessage } from '../utils/userProfileMessage';
+import config from '../config';
+import { sendForgetPasswordEmail } from '../services/email.service';
 
-export const getUsers = async (
-  req: Request,
-  res: Response,
-  next: NextFunction
-): Promise<void> => {
+export const getUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
     const users = await User.find();
     res.status(200).json(users);
@@ -35,13 +33,10 @@ export const registerController = async (
 ): Promise<void> => {
   try {
     const userData = req.body;
-    const { name, email, password, mobile, language, selfDescription } =
-      req.body;
+    const { name, email, password, mobile, language, selfDescription } = req.body;
 
     if (!name || !email || !password || !language) {
-      const error: ErrorWithStatus = new Error(
-        authErrorMessages.MISSING_REGISTRATION_FIELD
-      );
+      const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
       error.status = ClientErrorStatus.BAD_REQUEST;
       return next(error);
     }
@@ -54,9 +49,7 @@ export const registerController = async (
       language,
       selfDescription,
     } as IUser);
-    res
-      .status(201)
-      .json({ message: authSuccessMessage.REGISTER_SUCCESSFULLY, name: name });
+    res.status(201).json({ message: authSuccessMessage.REGISTER_SUCCESSFULLY, name: name });
   } catch (error: any) {
     const err: ErrorWithStatus = new Error();
     err.status = error.status || ClientErrorStatus.BAD_REQUEST;
@@ -74,9 +67,10 @@ export const loginController = async (
   try {
     const token = await authServices.login(email, password);
 
-    res.json({
-      message: authSuccessMessage.LOGIN_SUCCESSFULLY,
-      token: token,
+    res.status(200).json({
+      message: 'Login successful',
+      token,
+      redirectUrl: `${config.loginCallBackURL}?token=${token}`,
     });
   } catch (e: any) {
     const err: ErrorWithStatus = new Error();
@@ -88,14 +82,11 @@ export const loginController = async (
   }
 };
 
-
-
 export const getUserProfileController = async (
   req: Request,
   res: Response,
   next: NextFunction
 ): Promise<void> => {
-  
   try {
     if (!req.user || !req.user.id) {
       const error: ErrorWithStatus = new Error(authErrorMessages.UNAUTHORIZED_ACCESS);
@@ -112,20 +103,16 @@ export const getUserProfileController = async (
     res.status(200).json({
       name: user.name,
       email: user.email,
-      mobile:user.mobile,
-      language:user.language,
-      selfDescription:user.selfDescription
-      
+      mobile: user.mobile,
+      language: user.language,
+      selfDescription: user.selfDescription,
     });
   } catch (error) {
     const err: ErrorWithStatus = new Error(authErrorMessages.FETCH_USER_ERROR);
     err.status = ClientErrorStatus.NOT_FOUND;
     next(err);
   }
-
-
-}
-
+};
 
 export const updateProfileController = async (
   req: Request,
@@ -134,7 +121,7 @@ export const updateProfileController = async (
 ): Promise<void> => {
   try {
     const userId = req.user?.id;
-    
+
     if (!userId) {
       const error: ErrorWithStatus = new Error(authErrorMessages.UNAUTHORIZED_ACCESS);
       error.status = ClientErrorStatus.UNAUTHORIZED;
@@ -142,26 +129,26 @@ export const updateProfileController = async (
     }
 
     const { name, language, mobile, selfDescription } = req.body;
-    
+
     if (!language) {
       const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
       error.status = ClientErrorStatus.BAD_REQUEST;
       return next(error);
     }
-    
+
     // make sure updated data is useful
     if (name && name.trim() === '') {
       const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
       error.status = ClientErrorStatus.BAD_REQUEST;
       return next(error);
     }
-    
+
     if (mobile && mobile.trim() === '') {
       const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
       error.status = ClientErrorStatus.BAD_REQUEST;
       return next(error);
     }
-    
+
     if (selfDescription && selfDescription.trim() === '') {
       const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
       error.status = ClientErrorStatus.BAD_REQUEST;
@@ -172,7 +159,7 @@ export const updateProfileController = async (
       name,
       language,
       mobile,
-      selfDescription
+      selfDescription,
     });
 
     if (!updatedUser) {
@@ -188,8 +175,8 @@ export const updateProfileController = async (
         email: updatedUser.email,
         language: updatedUser.language,
         mobile: updatedUser.mobile,
-        selfDescription: updatedUser.selfDescription
-      }
+        selfDescription: updatedUser.selfDescription,
+      },
     });
   } catch (error) {
     next(error);
@@ -206,24 +193,18 @@ export const verifyEmail = async (
     const verification = await VerificationToken.findOne({ token });
 
     if (!verification) {
-      res
-        .status(400)
-        .json({ message: authErrorMessages.INVALID_VERIFICATION_LINK });
+      res.status(400).json({ message: authErrorMessages.INVALID_VERIFICATION_LINK });
       return;
     }
 
     if (new Date() > verification.expiresAt) {
-      res
-        .status(400)
-        .json({ message: authErrorMessages.EXPIRED_VERIFICATION_LINK });
+      res.status(400).json({ message: authErrorMessages.EXPIRED_VERIFICATION_LINK });
     }
 
     await User.findByIdAndUpdate(verification.userId, { activated: true });
     await VerificationToken.deleteOne({ token });
 
-    res
-      .status(200)
-      .json({ message: authSuccessMessage.EMAIL_VERIFY_SUCCESSFULLY });
+    res.status(200).json({ message: authSuccessMessage.EMAIL_VERIFY_SUCCESSFULLY });
   } catch (error: any) {
     const err: ErrorWithStatus = new Error();
     err.status = ClientErrorStatus.BAD_REQUEST;
@@ -247,11 +228,9 @@ export const resendVerificationEmail = async (
     }
 
     if (user.activated)
-      res
-        .status(400)
-        .json({ message: authErrorMessages.EMAIL_ALREADY_REGISTERED });
+      res.status(400).json({ message: authErrorMessages.EMAIL_ALREADY_REGISTERED });
 
-    const token = crypto.randomBytes(32).toString("hex");
+    const token = crypto.randomBytes(32).toString('hex');
     const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
     await VerificationToken.findOneAndUpdate(
@@ -262,9 +241,7 @@ export const resendVerificationEmail = async (
 
     await sendVerificationEmail(email, token, user.name);
 
-    res
-      .status(200)
-      .json({ message: authSuccessMessage.EMAIL_RESEND_SUCCESSFULLY });
+    res.status(200).json({ message: authSuccessMessage.EMAIL_RESEND_SUCCESSFULLY });
   } catch (error: any) {
     res.status(500).json({
       message: ServeErrorMessage.INTERNAL_SERVER_ERROR,
@@ -272,8 +249,41 @@ export const resendVerificationEmail = async (
     });
   }
 };
+export const requestResetPassword = async (req: Request, res: Response, next: NextFunction) => {
+  const { email } = req.body;
 
+  try {
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: 'Email not found' });
+    }
 
+    const token = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
-export default { getUsers, registerController, loginController, updateProfileController };
+    await VerificationToken.findOneAndUpdate(
+      { userId: user._id },
+      { token, expiresAt },
+      { upsert: true }
+    );
 
+    await sendForgetPasswordEmail(email, token, user.name);
+
+    res.status(200).json({ message: 'Reset email sent successfully' });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const userController = {
+  getUsers,
+  registerController,
+  loginController,
+  updateProfileController,
+  getUserProfileController,
+  verifyEmail,
+  resendVerificationEmail,
+  requestResetPassword,
+};
+
+export default userController;

--- a/src/routes/v1/api.ts
+++ b/src/routes/v1/api.ts
@@ -1,5 +1,5 @@
-import express, { NextFunction } from "express";
-import { Request, Response, Router } from "express";
+import express, { NextFunction } from 'express';
+import { Request, Response, Router } from 'express';
 import {
   getUsers,
   registerController,
@@ -8,15 +8,16 @@ import {
   getUserProfileController,
   verifyEmail,
   resendVerificationEmail,
-} from "../../controllers/user.controller";
-import validateBody from "../../middlewares/validation/auth.validation";
-import authValidationSchema from "../../validator/auth/authSchema";
-import authMiddleware from "../../middlewares/JWT/auth.middleware";
-import passport from "../../middlewares/thirdPartyAuth/passport";
-import { IUser } from "../../models/User";
-import config from "../../config";
+} from '../../controllers/user.controller';
+import validateBody from '../../middlewares/validation/auth.validation';
+import authValidationSchema from '../../validator/auth/authSchema';
+import authMiddleware from '../../middlewares/JWT/auth.middleware';
+import passport from '../../middlewares/thirdPartyAuth/passport';
+import { IUser } from '../../models/User';
+import config from '../../config';
 const router = express.Router();
-import { authErrorMessages } from "../../utils/errorMessages";
+import { authErrorMessages } from '../../utils/errorMessages';
+import userController from '../../controllers/user.controller';
 
 /**
  * @swagger
@@ -471,41 +472,30 @@ import { authErrorMessages } from "../../utils/errorMessages";
  *                   example: ["Unexpected server issue."]
  */
 
-router.get("/users", getUsers);
+router.get('/users', getUsers);
 
-router.post(
-  "/users/register",
-  validateBody(authValidationSchema.register),
-  registerController
-);
+router.post('/users/register', validateBody(authValidationSchema.register), registerController);
 
-router.post(
-  "/users/login",
-  validateBody(authValidationSchema.login),
-  loginController
-);
+router.post('/users/login', validateBody(authValidationSchema.login), loginController);
 
-router.get("/users/verify-email", verifyEmail);
-router.post("/users/resend-verification", resendVerificationEmail);
+router.get('/users/verify-email', verifyEmail);
+router.post('/users/resend-verification', resendVerificationEmail);
 router.patch(
-  "/users/update",
+  '/users/update',
   authMiddleware,
   validateBody(authValidationSchema.update),
   updateProfileController
 );
 
-router.get("/users/profile", authMiddleware, getUserProfileController);
+router.get('/users/profile', authMiddleware, getUserProfileController);
 
 //frontend need to trigger this at the begin to trigger google login page
-router.get(
-  "/users/googleAuth",
-  passport.authenticate("google", { scope: ["profile", "email"] })
-);
+router.get('/users/googleAuth', passport.authenticate('google', { scope: ['profile', 'email'] }));
 
 //if login successful trigger redirect , if login fail trigger route /loginFail
 router.get(
-  "/users/googleAuth/callback",
-  passport.authenticate("google", {
+  '/users/googleAuth/callback',
+  passport.authenticate('google', {
     failureRedirect: `${config.api.prefix}/users/loginFail`,
   }),
   async (req: Request, res: Response) => {
@@ -517,7 +507,7 @@ router.get(
       const token: string = user.generateLoginToken();
       res.redirect(`${config.loginCallBackURL}?token=${token}`);
     } catch (error) {
-      console.error("Google auth fail:", error);
+      console.error('Google auth fail:', error);
       res.redirect(`${config.api.prefix}/users/loginFail`);
     }
   }
@@ -525,9 +515,17 @@ router.get(
 
 //NOTE!!!: all auth error will be redirect to this route temporary including login/signup failure
 //do error handling in front end
-router.get("/users/loginFail", (req: Request, res: Response) => {
-
+router.get('/users/loginFail', (req: Request, res: Response) => {
   res.redirect(`${config.loginCallBackURL}/?authError=${true}`);
 });
+
+router.post(
+  '/users/forgot-password',
+  userController.requestResetPassword as (
+    req: Request,
+    res: Response,
+    next: NextFunction
+  ) => Promise<void>
+);
 
 export default router;

--- a/src/services/auth.service.test.ts
+++ b/src/services/auth.service.test.ts
@@ -1,228 +1,289 @@
-// Set JWT_SECRET first to avoid configuration warnings
-process.env.JWT_SECRET = "testSecret";
-import config from "../config";
-config.jwtSecret = process.env.JWT_SECRET;
+import { User, IUser } from '../models/User';
+import VerificationToken from '../models/VerificationToken';
+import { NextFunction, Request, Response } from 'express';
+import { ErrorWithStatus } from '../middlewares/ErrorHandler';
+import { ClientErrorStatus } from '../utils/errorStatusCode';
 
-import authServices from "../services/auth.service";
-import { User, IUser } from "../models/User";
-import bcrypt from "bcrypt";
-import jwt from "jsonwebtoken";
-import { authErrorMessages } from "../utils/errorMessages";
+import { authErrorMessages, ServeErrorMessage } from '../utils/errorMessages';
+import crypto from 'crypto';
+import { sendVerificationEmail } from '../services/email.service';
+import authServices from '../services/auth.service';
+import { updateProfile } from '../services/user.service';
+import { authSuccessMessage } from '../utils/successMessage';
+import { userProfileMessage } from '../utils/userProfileMessage';
+import config from '../config';
+import { sendForgetPasswordEmail } from '../services/email.service';
 
-class TestError extends Error {
-  status?: number;
-  details?: string[];
-}
+export const getUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const users = await User.find();
+    res.status(200).json(users);
+  } catch (error) {
+    const err: ErrorWithStatus = new Error();
+    err.status = ClientErrorStatus.BAD_REQUEST;
+    err.message = (error as Error).message;
+    next(error);
+  }
+};
 
-interface MockUser {
-  _id: string;
-  name: string;
-  email: string;
-  password: string;
-  language: string;
-  mobile: string;
-  selfDescription: string;
-  save: jest.Mock;
-  generateLoginToken: jest.Mock;
-  findByCredential?: jest.Mock;
-}
+export const registerController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userData = req.body;
+    const { name, email, password, mobile, language, selfDescription } = req.body;
 
-jest.mock("../models/User");
-jest.mock("bcrypt");
-jest.mock("jsonwebtoken");
+    if (!name || !email || !password || !language) {
+      const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
+      error.status = ClientErrorStatus.BAD_REQUEST;
+      return next(error);
+    }
 
-describe("Auth Service Unit Tests", () => {
-  const mockUserData: MockUser = {
-    _id: "1234567890abcdef12345678",
-    name: "Test User",
-    email: "test@example.com",
-    password: "password123",
-    language: "en",
-    mobile: "+61412345678",
-    selfDescription: "I am a test user",
-    save: jest.fn(),
-    generateLoginToken: jest.fn(),
-  };
+    await authServices.register({
+      name,
+      email,
+      password,
+      mobile,
+      language,
+      selfDescription,
+    } as IUser);
+    res.status(201).json({ message: authSuccessMessage.REGISTER_SUCCESSFULLY, name: name });
+  } catch (error: any) {
+    const err: ErrorWithStatus = new Error();
+    err.status = error.status || ClientErrorStatus.BAD_REQUEST;
+    err.message = (error as Error).message;
+    next(err);
+  }
+};
 
-  const mockCredentials = {
-    email: "test@example.com",
-    password: "password123",
-  };
+export const loginController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  const { email, password } = req.body;
+  try {
+    const token = await authServices.login(email, password);
 
-  beforeAll(() => {});
+    res.status(200).json({
+      message: 'Login successful',
+      token,
+      redirectUrl: `${config.loginCallBackURL}?token=${token}`,
+    });
+  } catch (e: any) {
+    const err: ErrorWithStatus = new Error();
+    err.status = ClientErrorStatus.UNAUTHORIZED;
+    err.message = e.message;
+    next(err);
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-    mockUserData.save.mockReset();
-    mockUserData.generateLoginToken.mockReset();
-  });
+    next(e); // Pass the error to the error handler
+  }
+};
 
-  afterAll(() => {});
+export const getUserProfileController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    if (!req.user || !req.user.id) {
+      const error: ErrorWithStatus = new Error(authErrorMessages.UNAUTHORIZED_ACCESS);
+      error.status = ClientErrorStatus.UNAUTHORIZED;
+      return next(error);
+    }
+    const user = await User.findById(req.user.id);
 
-  describe("register() - User Registration", () => {
-    it("should successfully register a new user", async () => {
-      mockUserData.save.mockResolvedValue(mockUserData);
+    if (!user) {
+      const error: ErrorWithStatus = new Error(authErrorMessages.UNAUTHORIZED_ACCESS);
+      error.status = ClientErrorStatus.UNAUTHORIZED;
+      return next(error);
+    }
+    res.status(200).json({
+      name: user.name,
+      email: user.email,
+      mobile: user.mobile,
+      language: user.language,
+      selfDescription: user.selfDescription,
+    });
+  } catch (error) {
+    const err: ErrorWithStatus = new Error(authErrorMessages.FETCH_USER_ERROR);
+    err.status = ClientErrorStatus.NOT_FOUND;
+    next(err);
+  }
+};
 
-      (User as jest.Mocked<any>).mockImplementation(
-        (userData: Partial<IUser>) => {
-          return mockUserData;
-        }
-      );
+export const updateProfileController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const userId = req.user?.id;
 
-      await authServices.register(mockUserData as any);
+    if (!userId) {
+      const error: ErrorWithStatus = new Error(authErrorMessages.UNAUTHORIZED_ACCESS);
+      error.status = ClientErrorStatus.UNAUTHORIZED;
+      return next(error);
+    }
 
-      expect(User).toHaveBeenCalledWith(
-        expect.objectContaining({
-          name: mockUserData.name,
-          email: mockUserData.email,
-          password: mockUserData.password,
-          language: mockUserData.language,
-          mobile: mockUserData.mobile,
-          selfDescription: mockUserData.selfDescription,
-        })
-      );
-      expect(mockUserData.save).toHaveBeenCalled();
+    const { name, language, mobile, selfDescription } = req.body;
+
+    if (!language) {
+      const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
+      error.status = ClientErrorStatus.BAD_REQUEST;
+      return next(error);
+    }
+
+    // make sure updated data is useful
+    if (name && name.trim() === '') {
+      const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
+      error.status = ClientErrorStatus.BAD_REQUEST;
+      return next(error);
+    }
+
+    if (mobile && mobile.trim() === '') {
+      const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
+      error.status = ClientErrorStatus.BAD_REQUEST;
+      return next(error);
+    }
+
+    if (selfDescription && selfDescription.trim() === '') {
+      const error: ErrorWithStatus = new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
+      error.status = ClientErrorStatus.BAD_REQUEST;
+      return next(error);
+    }
+
+    const updatedUser = await updateProfile(userId, {
+      name,
+      language,
+      mobile,
+      selfDescription,
     });
 
-    it("should throw conflict error when email already exists", async () => {
-      const mockError = new TestError(authErrorMessages.DUPLICATION_EMAIL);
-      mockError.status = 409;
-      (mockError as any).code = 11000;
+    if (!updatedUser) {
+      const error: ErrorWithStatus = new Error(userProfileMessage.UPDATE_PROFILE_NOT_FOUND);
+      error.status = ClientErrorStatus.NOT_FOUND;
+      return next(error);
+    }
 
-      mockUserData.save.mockRejectedValue(mockError);
-      (User as jest.Mocked<any>).mockImplementation(() => mockUserData);
-
-      await expect(
-        authServices.register(mockUserData as any)
-      ).rejects.toMatchObject({
-        message: authErrorMessages.DUPLICATION_EMAIL,
-        status: 409,
-      });
+    res.status(200).json({
+      message: userProfileMessage.UPDATE_PROFILE_SUCCESS,
+      user: {
+        name: updatedUser.name,
+        email: updatedUser.email,
+        language: updatedUser.language,
+        mobile: updatedUser.mobile,
+        selfDescription: updatedUser.selfDescription,
+      },
     });
+  } catch (error) {
+    next(error);
+  }
+};
 
-    it("should handle unknown database errors", async () => {
-      mockUserData.save.mockRejectedValue(
-        new Error("Database connection failed")
-      );
-      (User as jest.Mocked<any>).mockImplementation(() => mockUserData);
+export const verifyEmail = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { token } = req.query;
+    const verification = await VerificationToken.findOne({ token });
 
-      await expect(authServices.register(mockUserData as any)).rejects.toThrow(
-        authErrorMessages.UNKNOWN_ERROR
-      );
+    if (!verification) {
+      res.status(400).json({ message: authErrorMessages.INVALID_VERIFICATION_LINK });
+      return;
+    }
+
+    if (new Date() > verification.expiresAt) {
+      res.status(400).json({ message: authErrorMessages.EXPIRED_VERIFICATION_LINK });
+    }
+
+    await User.findByIdAndUpdate(verification.userId, { activated: true });
+    await VerificationToken.deleteOne({ token });
+
+    res.status(200).json({ message: authSuccessMessage.EMAIL_VERIFY_SUCCESSFULLY });
+  } catch (error: any) {
+    const err: ErrorWithStatus = new Error();
+    err.status = ClientErrorStatus.BAD_REQUEST;
+    err.message = (error as Error).message;
+    next(error);
+  }
+};
+
+export const resendVerificationEmail = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { email } = req.body;
+    const user = await User.findOne({ email });
+
+    if (!user) {
+      res.status(404).json({ message: authErrorMessages.INVALID_CREDENTIALS });
+      return;
+    }
+
+    if (user.activated)
+      res.status(400).json({ message: authErrorMessages.EMAIL_ALREADY_REGISTERED });
+
+    const token = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+    await VerificationToken.findOneAndUpdate(
+      { userId: user._id },
+      { token, expiresAt },
+      { upsert: true }
+    );
+
+    await sendVerificationEmail(email, token, user.name);
+
+    res.status(200).json({ message: authSuccessMessage.EMAIL_RESEND_SUCCESSFULLY });
+  } catch (error: any) {
+    res.status(500).json({
+      message: ServeErrorMessage.INTERNAL_SERVER_ERROR,
+      error: error.message,
     });
+  }
+};
+export const requestResetPassword = async (req: Request, res: Response, next: NextFunction) => {
+  const { email } = req.body;
 
-    it("should throw error when required fields are missing", async () => {
-      const invalidUserData = {
-        email: "test@example.com",
-        password: "password123",
-      };
+  try {
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: 'Email not found' });
+    }
 
-      (User as jest.Mocked<any>).mockImplementation(
-        (userData: Partial<IUser>) => {
-          if (!userData.name || !userData.language) {
-            throw new Error(authErrorMessages.MISSING_REGISTRATION_FIELD);
-          }
-          return mockUserData;
-        }
-      );
+    const token = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
-      await expect(
-        authServices.register(invalidUserData as any)
-      ).rejects.toThrow(authErrorMessages.UNKNOWN_ERROR);
-    });
-  });
+    await VerificationToken.findOneAndUpdate(
+      { userId: user._id },
+      { token, expiresAt },
+      { upsert: true }
+    );
 
-  describe("login() - User Login", () => {
-    it("should log in successfully and return a token", async () => {
-      const mockUser = {
-        ...mockUserData,
-        findByCredential: jest.fn().mockResolvedValue(mockUserData),
-      };
+    await sendForgetPasswordEmail(email, token, user.name);
 
-      (User as jest.Mocked<any>).findByCredential = jest
-        .fn()
-        .mockResolvedValue(mockUser);
-      mockUser.generateLoginToken.mockReturnValue("mockToken123");
+    res.status(200).json({ message: 'Reset email sent successfully' });
+  } catch (error) {
+    next(error);
+  }
+};
 
-      (bcrypt.compare as jest.Mocked<any>).mockResolvedValue(true);
+const userController = {
+  getUsers,
+  registerController,
+  loginController,
+  updateProfileController,
+  getUserProfileController,
+  verifyEmail,
+  resendVerificationEmail,
+  requestResetPassword,
+};
 
-      const token = await authServices.login(
-        mockCredentials.email,
-        mockCredentials.password
-      );
-
-      expect(User.findByCredential).toHaveBeenCalledWith(
-        mockCredentials.email,
-        mockCredentials.password
-      );
-      expect(mockUser.generateLoginToken).toHaveBeenCalled();
-      expect(token).toBe("mockToken123");
-    });
-
-    it("should throw error when credentials are invalid", async () => {
-      (User as jest.Mocked<any>).findByCredential = jest
-        .fn()
-        .mockRejectedValue(new Error(authErrorMessages.INVALID_CREDENTIALS));
-
-      await expect(
-        authServices.login("wrong@example.com", "wrongpass")
-      ).rejects.toThrow(authErrorMessages.INVALID_CREDENTIALS);
-    });
-
-    it("should handle JWT generation errors", async () => {
-      const mockUser = {
-        ...mockUserData,
-        findByCredential: jest.fn().mockResolvedValue(mockUserData),
-        generateLoginToken: jest.fn().mockImplementation(() => {
-          throw new Error(authErrorMessages.JWT_TOKEN_GENERATION_ERROR);
-        }),
-      };
-
-      (User as jest.Mocked<any>).findByCredential = jest
-        .fn()
-        .mockResolvedValue(mockUser);
-      (bcrypt.compare as jest.Mocked<any>).mockResolvedValue(true);
-
-      await expect(
-        authServices.login("test@example.com", "password123")
-      ).rejects.toThrow(authErrorMessages.JWT_TOKEN_GENERATION_ERROR);
-    });
-
-    it("should throw error if JWT secret is not set", async () => {
-      const originalJwtSecret = config.jwtSecret;
-      config.jwtSecret = "";
-
-      const mockUser = {
-        ...mockUserData,
-        findByCredential: jest.fn().mockResolvedValue(mockUserData),
-        generateLoginToken: jest.fn().mockImplementation(() => {
-          if (!config.jwtSecret) {
-            throw new Error(authErrorMessages.JWT_SECRET_NOT_SET);
-          }
-          return "token";
-        }),
-      };
-
-      (User as jest.Mocked<any>).findByCredential = jest
-        .fn()
-        .mockResolvedValue(mockUser);
-      (bcrypt.compare as jest.Mocked<any>).mockResolvedValue(true);
-
-      await expect(
-        authServices.login("test@example.com", "password123")
-      ).rejects.toThrow(authErrorMessages.JWT_SECRET_NOT_SET);
-
-      config.jwtSecret = originalJwtSecret;
-    });
-
-    it("should throw error when password is incorrect", async () => {
-      (User as jest.Mocked<any>).findByCredential = jest
-        .fn()
-        .mockRejectedValue(new Error(authErrorMessages.INVALID_CREDENTIALS));
-
-      await expect(
-        authServices.login("test@example.com", "wrongpassword")
-      ).rejects.toThrow(authErrorMessages.INVALID_CREDENTIALS);
-    });
-  });
-});
+export default userController;

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -1,16 +1,17 @@
-import nodemailer from "nodemailer";
-import config from "../config";
-import { authErrorMessages } from "../utils/errorMessages";
-import emailGenerator from "../templates/verificationEmailTemplate";
+import nodemailer from 'nodemailer';
+import config from '../config';
+import { authErrorMessages } from '../utils/errorMessages';
+import emailGenerator from '../templates/verificationEmailTemplate';
+import generateForgetPasswordEmail from '../templates/forgetPasswordEmailTemplate';
 
 export const sendVerificationEmail = async (
   email: string,
   token: string,
-  receiverName:string
+  receiverName: string
 ): Promise<void> => {
   try {
     const transporter = nodemailer.createTransport({
-      service: "gmail",
+      service: 'gmail',
       auth: {
         user: config.emailUser,
         pass: config.emailPasskey,
@@ -19,9 +20,28 @@ export const sendVerificationEmail = async (
 
     const verificationLink = `${config.emailRedirectURL}/api/v1/users/verify-email?token=${token}`;
 
-    const mailOptions = emailGenerator(verificationLink, email,receiverName);
+    const mailOptions = emailGenerator(verificationLink, email, receiverName);
     await transporter.sendMail(mailOptions);
   } catch (error) {
     throw new Error(authErrorMessages.SENDING_EMAIL_ERROR);
   }
+};
+
+export const sendForgetPasswordEmail = async (
+  email: string,
+  token: string,
+  receiverName: string
+): Promise<void> => {
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: config.emailUser,
+      pass: config.emailPasskey,
+    },
+  });
+
+  const resetLink = `${config.emailRedirectURL}/reset-password?token=${token}`;
+  const mailOptions = generateForgetPasswordEmail(resetLink, email, receiverName);
+
+  await transporter.sendMail(mailOptions);
 };

--- a/src/templates/forgetPasswordEmailTemplate.ts
+++ b/src/templates/forgetPasswordEmailTemplate.ts
@@ -1,0 +1,33 @@
+import config from '../config';
+
+type EmailTemplate = {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+};
+
+const generateForgetPasswordEmail = (
+  resetLink: string,
+  receiverEmail: string,
+  receiverName: string
+): EmailTemplate => {
+  return {
+    from: config.emailUser,
+    to: receiverEmail,
+    subject: 'IFA Translator - Reset Your Password',
+    html: `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: auto; background: #fff; padding: 30px; border-radius: 10px; box-shadow: 0 0 10px rgba(0,0,0,0.1)">
+      <h2 style="color: #2C3E50;">Reset Your Password</h2>
+      <p>Dear ${receiverName},</p>
+      <p>You requested to reset your password. Click the button below to continue:</p>
+      <a href="${resetLink}" style="display:inline-block;padding:10px 20px;background:#E67E22;color:white;border-radius:5px;text-decoration:none;">Reset Password</a>
+      <p>This link will expire in 1 hour. If you didn't request this, you can safely ignore this email.</p>
+      <hr/>
+      <p style="font-size: 12px; color: #888;">IFA Translator Team | ${config.emailUser}</p>
+    </div>
+    `,
+  };
+};
+
+export default generateForgetPasswordEmail;


### PR DESCRIPTION
feat: IT-23-Forget-user-password(Backend)

Implemented backend functionality for Forget Password: 
- Added requestResetPassword controller
- Check if email exists
- Generate reset token and save it for 1 hour
- Create a forget password email template and send it to the user
- Add new end point POST /users/forgot-password

<img width="1155" alt="image" src="https://github.com/user-attachments/assets/44437dc6-32e4-49c2-b919-5dcbee46eabc" />
<img width="1154" alt="image" src="https://github.com/user-attachments/assets/e509f015-65fe-4211-a727-19df281ae5d0" />

Resolve IT-23(Backend)