### PR TITLE
 feat: IT-23-BE-Forget-user-password

### DIFF
--- a/src/controllers/user.controller.ts
+++ b/src/controllers/user.controller.ts
@@ -13,6 +13,7 @@ import { authSuccessMessage } from '../utils/successMessage';
 import { userProfileMessage } from '../utils/userProfileMessage';
 
 import config from '../config';
+import { sendForgetPasswordEmail } from '../services/email.service';
 
 export const getUsers = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
   try {
@@ -247,4 +248,41 @@ export const resendVerificationEmail = async (req: Request, res: Response): Prom
   }
 };
 
-export default { getUsers, registerController, loginController, updateProfileController };
+export const requestResetPassword = async (req: Request, res: Response, next: NextFunction) => {
+  const { email } = req.body;
+
+  try {
+    const user = await User.findOne({ email });
+    if (!user) {
+      return res.status(404).json({ message: 'Email not found' });
+    }
+
+    const token = crypto.randomBytes(32).toString('hex');
+    const expiresAt = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
+
+    await VerificationToken.findOneAndUpdate(
+      { userId: user._id },
+      { token, expiresAt },
+      { upsert: true }
+    );
+
+    await sendForgetPasswordEmail(email, token, user.name);
+
+    res.status(200).json({ message: 'Reset email sent successfully' });
+  } catch (error) {
+    next(error);
+  }
+};
+
+const userController = {
+  getUsers,
+  registerController,
+  loginController,
+  updateProfileController,
+  getUserProfileController,
+  verifyEmail,
+  resendVerificationEmail,
+  requestResetPassword,
+};
+
+export default userController;

--- a/src/routes/v1/api.ts
+++ b/src/routes/v1/api.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { Request, Response } from 'express';
+import { Request, Response, NextFunction } from 'express';
 import {
   getUsers,
   registerController,
@@ -8,6 +8,7 @@ import {
   getUserProfileController,
   verifyEmail,
   resendVerificationEmail,
+  requestResetPassword,
 } from '../../controllers/user.controller';
 import meetingRoomController from '../../controllers/meetingRoom.controller';
 import validateBody from '../../middlewares/validation/auth.validation';
@@ -497,6 +498,63 @@ const router = express.Router();
  *                   items:
  *                     type: string
  *                   example: ["Unexpected server issue."]
+ * /users/forgot-password:
+ *   post:
+ *     summary: Request a password reset
+ *     description: Sends a password reset link to the user's email if the email is registered.
+ *     tags:
+ *       - Authentication
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required:
+ *               - email
+ *             properties:
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 description: The user's registered email address
+ *                 example: user@example.com
+ *     responses:
+ *       200:
+ *         description: Reset email sent successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Reset email sent successfully
+ *       404:
+ *         description: Email not found
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 message:
+ *                   type: string
+ *                   example: Email not found
+ *       500:
+ *         description: Internal server error
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 success:
+ *                   type: boolean
+ *                   example: false
+ *                 status:
+ *                   type: integer
+ *                   example: 500
+ *                 message:
+ *                   type: string
+ *                   example: Internal Server Error
  * /meetings/createNewRoom:
  *   post:
  *     summary: Create a new meeting room
@@ -629,6 +687,11 @@ router.get(
 router.get('/users/loginFail', (req: Request, res: Response) => {
   res.redirect(`${config.loginCallBackURL}/?authError=${true}`);
 });
+
+router.post(
+  '/users/forgot-password',
+  requestResetPassword as (req: Request, res: Response, next: NextFunction) => Promise<void>
+);
 
 router.post('/meetings/createNewRoom', meetingRoomController.createNewRoomController);
 router.post('/meetings/info', meetingRoomController.getParticipants);

--- a/src/services/email.service.ts
+++ b/src/services/email.service.ts
@@ -2,6 +2,7 @@ import nodemailer from 'nodemailer';
 import config from '../config';
 import { authErrorMessages } from '../utils/errorMessages';
 import emailGenerator from '../templates/verificationEmailTemplate';
+import generateForgetPasswordEmail from '../templates/forgetPasswordEmailTemplate';
 
 export const sendVerificationEmail = async (
   email: string,
@@ -24,4 +25,23 @@ export const sendVerificationEmail = async (
   } catch (error) {
     throw new Error(authErrorMessages.SENDING_EMAIL_ERROR);
   }
+};
+
+export const sendForgetPasswordEmail = async (
+  email: string,
+  token: string,
+  receiverName: string
+): Promise<void> => {
+  const transporter = nodemailer.createTransport({
+    service: 'gmail',
+    auth: {
+      user: config.emailUser,
+      pass: config.emailPasskey,
+    },
+  });
+
+  const resetLink = `${config.emailRedirectURL}/reset-password?token=${token}`;
+  const mailOptions = generateForgetPasswordEmail(resetLink, email, receiverName);
+
+  await transporter.sendMail(mailOptions);
 };

--- a/src/templates/forgetPasswordEmailTemplate.ts
+++ b/src/templates/forgetPasswordEmailTemplate.ts
@@ -1,0 +1,162 @@
+import config from '../config';
+
+type EmailTemplate = {
+  from: string;
+  to: string;
+  subject: string;
+  html: string;
+};
+
+const generateForgetPasswordEmail = (
+  resetLink: string,
+  receiverEmail: string,
+  receiverName: string
+): EmailTemplate => {
+  return {
+    from: config.emailUser,
+    to: receiverEmail,
+    subject: 'IFA Translator - Reset Your Password',
+    html: `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Reset Password</title>
+  <style>
+    body {
+      font-family: 'Arial', sans-serif;
+      margin: 0;
+      padding: 0;
+      background-color: #f4f6f9;
+      color: #333;
+      line-height: 1.6;
+    }
+    table {
+      border-spacing: 0;
+      width: 100%;
+      max-width: 600px;
+      margin: 0 auto;
+    }
+    td {
+      padding: 20px;
+      text-align: left;
+    }
+    .header {
+      background-color: #2C3E50;
+      color: #ffffff;
+      font-size: 28px;
+      font-weight: bold;
+      padding: 20px 0;
+      text-align: center;
+    }
+    .header img {
+      width: 40px;
+      vertical-align: middle;
+      margin-right: 10px;
+    }
+    .content {
+      background-color: #ffffff;
+      color: #333;
+      font-size: 16px;
+      padding: 30px;
+      border-radius: 8px;
+      box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    }
+    .content p {
+      font-size: 16px;
+      margin-bottom: 10px;
+    }
+    .button {
+      background-color: #E67E22;
+      color: white;
+      padding: 15px 30px;
+      font-size: 18px;
+      font-weight: bold;
+      text-decoration: none;
+      border-radius: 5px;
+      display: inline-block;
+      margin: 20px 0;
+    }
+    .button:hover {
+      background-color: #e04e2f;
+    }
+    .footer {
+      font-size: 13px;
+      color: #333333;
+      background-color: #3498DB;
+      padding: 20px;
+      text-align: left;
+    }
+    .footer p {
+      margin: 5px 0;
+    }
+    .social-icons img {
+      width: 32px;
+      margin-right: 15px;
+      vertical-align: middle;
+    }
+    @media (max-width: 600px) {
+      .header {
+        font-size: 24px;
+        padding: 15px 0;
+      }
+      .content {
+        padding: 20px;
+        font-size: 14px;
+      }
+      .button {
+        font-size: 16px;
+        padding: 12px 25px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <table>
+    <!-- Header -->
+    <tr>
+      <td class="header">
+        <img src="https://cdn.templates.unlayer.com/assets/1593141680866-reset.png" />
+        Reset Password
+      </td>
+    </tr>
+    <!-- Main Content -->
+    <tr>
+      <td class="content">
+        <p>Dear ${receiverName},</p>
+        <p>You requested to reset your password. Please click the button below to continue:</p>
+        <p><a href="${resetLink}" class="button">Reset Password</a></p>
+        <p>This link will expire in 1 hour. If you did not request a password reset, please ignore this email.</p>
+        <p>Best regards,<br/><strong>The IFA Translator Team</strong></p>
+      </td>
+    </tr>
+    <!-- Footer -->
+    <tr>
+      <td class="footer">
+        <p style="font-size: 18px;"><strong>Contact Information:</strong></p>
+        <p>Address: IFA Sydney Office</p>
+        <p>Email: <span>${config.emailUser}</span></p>
+        <div class="social-icons">
+          <a href="https://facebook.com" target="_blank">
+            <img src="https://cdn.tools.unlayer.com/social/icons/circle-white/facebook.png" alt="Facebook" />
+          </a>
+          <a href="https://twitter.com" target="_blank">
+            <img src="https://cdn.tools.unlayer.com/social/icons/circle-white/twitter.png" alt="Twitter" />
+          </a>
+          <a href="https://instagram.com" target="_blank">
+            <img src="https://cdn.tools.unlayer.com/social/icons/circle-white/instagram.png" alt="Instagram" />
+          </a>
+          <a href="https://linkedin.com" target="_blank">
+            <img src="https://cdn.tools.unlayer.com/social/icons/circle-white/linkedin.png" alt="LinkedIn" />
+          </a>
+        </div>
+        <p>Company © ${new Date().getFullYear()} All Rights Reserved</p>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`,
+  };
+};
+
+export default generateForgetPasswordEmail;


### PR DESCRIPTION
feat: IT-23-BE-Forget-user-password

Implemented backend functionality for Forget Password:

Added requestResetPassword controller

Check if email exists

Generate reset token and save it for 1 hour

Create a forget password email template and send it to the user

Add new end point POST /users/forgot-password
![image](https://github.com/user-attachments/assets/4479b97f-e31e-4080-a50b-0387090d4e0a)
![image](https://github.com/user-attachments/assets/1b11e403-77f4-48c6-a5ec-bd14bebd9966)
<img width="880" alt="image" src="https://github.com/user-attachments/assets/d4954d49-392e-40b1-820f-899b5575f061" />
Resolves: IT-23 (Backend)