### PR TITLE
feat/IT-43-User-Panel-Toggle-And-Rasie-Hand-Functionality

### DIFF
--- a/src/controllers/meetingRoom.controller.ts
+++ b/src/controllers/meetingRoom.controller.ts
@@ -60,6 +60,27 @@ export const getParticipants = async (
   }
 };
 
+export const getMeetingCreator = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { roomId } = req.body;
+    const creator = await meetingRoomServices.getMeetingCreatorId(roomId);
+
+    res.status(200).json({
+      message: meetingRoomSuccessMessage.FETCH_Creator_SUCCESSFULLY,
+      creator, //{id:string}
+    });
+  } catch (error) {
+    const err: ErrorWithStatus = new Error();
+    err.status = MeetingErrorStatus.BAD_REQUEST;
+    err.message = (error as Error).message;
+    next(err);
+  }
+};
+
 export const generateMeetingQRCodeController = async (
   req: Request,
   res: Response,
@@ -68,7 +89,9 @@ export const generateMeetingQRCodeController = async (
   try {
     const { roomId } = req.params;
     if (!roomId) {
-      const err: ErrorWithStatus = new Error(meetingErrorMessage.MISSING_ROOM_ID) as ErrorWithStatus;
+      const err: ErrorWithStatus = new Error(
+        meetingErrorMessage.MISSING_ROOM_ID
+      ) as ErrorWithStatus;
       err.status = MeetingErrorStatus.BAD_REQUEST;
       throw err;
     }
@@ -93,5 +116,6 @@ const meetingRoomController = {
   createNewRoomController,
   getParticipants,
   generateMeetingQRCodeController,
+  getMeetingCreator,
 };
 export default meetingRoomController;

--- a/src/routes/v1/api.ts
+++ b/src/routes/v1/api.ts
@@ -696,5 +696,6 @@ router.post(
 router.post('/meetings/createNewRoom', meetingRoomController.createNewRoomController);
 router.post('/meetings/info', meetingRoomController.getParticipants);
 router.get('/meetings/qr-code/:roomId', meetingRoomController.generateMeetingQRCodeController);
+router.post('/meetings/get-meeting-creator', meetingRoomController.getMeetingCreator);
 
 export default router;

--- a/src/services/meetingRoom.service.ts
+++ b/src/services/meetingRoom.service.ts
@@ -51,6 +51,38 @@ const saveInstantMeetingTranscript = async (
   await transcript.save();
 };
 
-const meetingRoomServices = { createMeetingRoom, getParticipantInfo, saveInstantMeetingTranscript };
+const getMeetingCreatorId = async (roomId: string): Promise<{ id: string } | undefined> => {
+  const meetingRoom = await MeetingRoom.findById(roomId).exec();
+  if (!meetingRoom) {
+    const err: ErrorWithStatus = new Error(meetingErrorMessage.ROOM_NOT_FOUND) as ErrorWithStatus;
+    err.status = MeetingErrorStatus.ROOM_NOT_FOUND;
+    throw err;
+  }
+
+  return { id: meetingRoom.creator.toString() };
+};
+
+const addParticipantToDataBase = async (
+  meetingId: string,
+  participantId: string
+): Promise<void> => {
+  await MeetingRoom.findByIdAndUpdate(
+    meetingId,
+    {
+      $addToSet: {
+        participant: new mongoose.Types.ObjectId(participantId),
+      },
+    },
+    { new: true }
+  );
+};
+
+const meetingRoomServices = {
+  createMeetingRoom,
+  getParticipantInfo,
+  saveInstantMeetingTranscript,
+  getMeetingCreatorId,
+  addParticipantToDataBase,
+};
 
 export default meetingRoomServices;

--- a/src/socket/socket.ts
+++ b/src/socket/socket.ts
@@ -29,7 +29,7 @@ export const socketHandler = (io: Server) => {
   io.on('connection', (socket: Socket) => {
     console.log('Socket connected:', socket.id);
 
-    socket.on('join-room', ({ roomId, userInitialStatusData }) => {
+    socket.on('join-room', async ({ roomId, userInitialStatusData }) => {
       const userId = userInitialStatusData.userId;
 
       if (!roomUsersMap.has(roomId)) {
@@ -42,6 +42,7 @@ export const socketHandler = (io: Server) => {
         return;
       }
       roomUsers.add(userId);
+      await meetingRoomServices.addParticipantToDataBase(roomId, userId);
       socket.join(roomId);
       console.log(`${userInitialStatusData.userName} joined room ${roomId}`);
 
@@ -61,6 +62,7 @@ export const socketHandler = (io: Server) => {
       console.log(`current room with room id:${roomId} status`, roomStatusMap.get(roomId));
       io.to(roomId).emit('broadcast-current-room-status', roomStatusMap.get(roomId));
       socket.emit('sync-room-status-list', currentRoomStatus);
+      io.to(roomId).emit('sync-room-participants-number', roomUsersMap.get(roomId)?.size);
     });
 
     socket.on('speech-text', async ({ roomId, text, user }) => {

--- a/src/utils/successMessage.ts
+++ b/src/utils/successMessage.ts
@@ -8,4 +8,5 @@ export enum meetingRoomSuccessMessage {
   CREATE_MEETING_ROOM_SUCCESSFULLY = 'Meeting Room created successful',
   FETCH_PARTICIPANT_SUCCESSFULLY = 'Participants retrieved successfully',
   QR_CODE_GENERATED_SUCCESSFULLY = 'QR code generated successfully.',
+  FETCH_Creator_SUCCESSFULLY = 'Fetch Meeting Room Creator Successfully',
 }


### PR DESCRIPTION
### feat/IT-43-44(backend)-User-Panel-Toggle-And-Rasie-Hand-Functionality

- Add Meeting Room Participant adding service for IT-44 and future 
- Add Api route to the api for fetch the meeting creator for IT-44 front end(only creator will show the share barcode and link panel  by default, the other user via join link to the meeting will not shown to the panel by default) 
- Add API controller for fetch creator Id
- Apply Socket to broadcast the current online participant to the front end for the userNumber on the nav bar(IT-43) 
- Add  successMessage for fetch meeting creator Id in utils

Resolve IT-43&44 Backend

### Testing

- Case1 when more then 1 participants had join meeting room

FE:
<img width="1274" alt="IT-43-FE-1" src="https://github.com/user-attachments/assets/2b0dcd70-b6dd-4207-b929-2fadadf9b977" />

BE:
<img width="996" alt="IT-43-BE1" src="https://github.com/user-attachments/assets/34737e9c-34ae-4716-a3ec-a7ac7542fb76" />

- Case2 Testing new api /meetings/get-meeting-creator

BE:
<img width="977" alt="it-44-BE2" src="https://github.com/user-attachments/assets/f1c35fe8-82c1-4ff5-9e12-db2b78885796" />

FE: (2 pictures here ， one is the creator view the other one is join meeting user view)

### Creator View By Default
<img width="1268" alt="it-44-creator-view-share-panel" src="https://github.com/user-attachments/assets/c45e218a-3e8e-4fb2-ae9c-df314b4e2bdd" />

### Joiner View By Default
<img width="1279" alt="joiner-view-by-default" src="https://github.com/user-attachments/assets/c6140dca-120b-4e46-b79a-bbfdf0fe7882" />

Note:  Backend should be enough till now to complete IT-44 frontend

