### PR TITLE
Feat/IT-41-Add-Language-Selector(BE)

### DIFF
--- a/src/controllers/meetingRoom.controller.ts
+++ b/src/controllers/meetingRoom.controller.ts
@@ -6,6 +6,7 @@ import meetingRoomServices from '../services/meetingRoom.service';
 import { meetingErrorMessage } from '../utils/errorMessages';
 import { meetingRoomSuccessMessage } from '../utils/successMessage';
 import { MeetingErrorStatus } from '../utils/errorStatusCode';
+import { historyRecordsRetranslation } from '../services/histroy-records-retranslation-service';
 
 export const createNewRoomController = async (
   req: Request,
@@ -112,10 +113,53 @@ export const generateMeetingQRCodeController = async (
   }
 };
 
+export const getMeetingRecordsController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { roomId } = req.body;
+    const meetingRecordArray =
+      await meetingRoomServices.fetchRawSpeechRecordsViaMeetingRoomID(roomId);
+
+    res.status(200).json({
+      message: meetingRoomSuccessMessage.FETCH_Creator_SUCCESSFULLY,
+      meetingRecordArray,
+    });
+  } catch (error) {
+    const err: ErrorWithStatus = new Error();
+    err.status = MeetingErrorStatus.INTERNAL_SERVER_ERROR;
+    err.message = (error as Error).message;
+    next(err);
+  }
+};
+
+export const reTranslateAllHistoryController = async (
+  req: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  try {
+    const { roomId, to } = req.body;
+    const newTranslationResponse = await historyRecordsRetranslation(roomId, to);
+    res.status(200).json({
+      newTranslationForHistoryTranscript: newTranslationResponse,
+    });
+  } catch (error) {
+    const err: ErrorWithStatus = new Error();
+    err.status = MeetingErrorStatus.INTERNAL_SERVER_ERROR;
+    err.message = (error as Error).message;
+    next(err);
+  }
+};
+
 const meetingRoomController = {
   createNewRoomController,
   getParticipants,
   generateMeetingQRCodeController,
   getMeetingCreator,
+  getMeetingRecordsController,
+  reTranslateAllHistoryController,
 };
 export default meetingRoomController;

--- a/src/routes/v1/api.ts
+++ b/src/routes/v1/api.ts
@@ -697,5 +697,13 @@ router.post('/meetings/createNewRoom', meetingRoomController.createNewRoomContro
 router.post('/meetings/info', meetingRoomController.getParticipants);
 router.get('/meetings/qr-code/:roomId', meetingRoomController.generateMeetingQRCodeController);
 router.post('/meetings/get-meeting-creator', meetingRoomController.getMeetingCreator);
+router.post(
+  '/meetings/fetch-meeting-history-records',
+  meetingRoomController.getMeetingRecordsController
+);
+router.post(
+  '/meetings/history-speech-retranslation',
+  meetingRoomController.reTranslateAllHistoryController
+);
 
 export default router;

--- a/src/services/histroy-records-retranslation-service.ts
+++ b/src/services/histroy-records-retranslation-service.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { v4 as uuidv4 } from 'uuid';
+import dotenv from 'dotenv';
+import meetingRoomServices from './meetingRoom.service';
+import { ArrayBreaker } from '../utils/historyBigArrayBreaker';
+dotenv.config();
+const key = process.env.AZURE_TRANSLATOR_KEY;
+const endpoint = 'https://api.cognitive.microsofttranslator.com';
+const location = process.env.AZURE_TRANSLATOR_REGION;
+//testing room Id:684454c7d79002dd299c71bd
+export const historyRecordsRetranslation = async (roomId: string, to: string) => {
+  const meetingRecordFetchResponse =
+    await meetingRoomServices.fetchRawSpeechRecordsViaMeetingRoomID(roomId);
+  const speechHistoryChunks: string[][] = ArrayBreaker(meetingRecordFetchResponse);
+
+  const reTranslationResult: string[] = [];
+
+  for (let i = 0; i < speechHistoryChunks.length; i++) {
+    console.log(i);
+    const chunk = speechHistoryChunks[i];
+
+    const response = await axios({
+      baseURL: endpoint,
+      url: '/translate',
+      method: 'post',
+      headers: {
+        'Ocp-Apim-Subscription-Key': key,
+        'Ocp-Apim-Subscription-Region': location,
+        'Content-Type': 'application/json',
+        'X-ClientTraceId': uuidv4().toString(),
+      },
+      params: {
+        'api-version': '3.0',
+        to,
+      },
+      data: chunk.map((text) => ({ Text: text })),
+    });
+
+    reTranslationResult.push(...response.data);
+  }
+  return reTranslationResult;
+};

--- a/src/services/meetingRoom.service.ts
+++ b/src/services/meetingRoom.service.ts
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 import { ErrorWithStatus } from '../middlewares/ErrorHandler';
 import { MeetingErrorStatus } from '../utils/errorStatusCode';
 import { meetingErrorMessage } from '../utils/errorMessages';
-import { SpeechTranscript } from '../models/MeetingRecords';
+import { SpeechTranscript, ISpeechTranscript } from '../models/MeetingRecords';
 
 const createMeetingRoom = async (
   creatorId: mongoose.Types.ObjectId,
@@ -76,6 +76,13 @@ const addParticipantToDataBase = async (
     { new: true }
   );
 };
+const fetchRawSpeechRecordsViaMeetingRoomID = async (meetingId: string): Promise<string[]> => {
+  const historyRecords = await SpeechTranscript.find({
+    meetingId: new mongoose.Types.ObjectId(meetingId),
+  }).sort({ createdAt: 1 });
+
+  return historyRecords.map((record: ISpeechTranscript) => record.rawSpeechText);
+};
 
 const meetingRoomServices = {
   createMeetingRoom,
@@ -83,6 +90,7 @@ const meetingRoomServices = {
   saveInstantMeetingTranscript,
   getMeetingCreatorId,
   addParticipantToDataBase,
+  fetchRawSpeechRecordsViaMeetingRoomID,
 };
 
 export default meetingRoomServices;

--- a/src/utils/historyBigArrayBreaker.ts
+++ b/src/utils/historyBigArrayBreaker.ts
@@ -1,0 +1,20 @@
+//because azure translator only allow maximum 100 string per call
+//we need to use this function to break large history into smaller chunk
+
+//data  structure  of result [[speech1....speech100],[speech101...speech200],[...],[...]]
+
+export const ArrayBreaker = (largeArray: string[]): string[][] => {
+  const chunkSize = 100;
+  const totalChunk = Math.ceil(largeArray.length / chunkSize);
+
+  const result: string[][] = [];
+
+  for (let i = 0; i < totalChunk; i++) {
+    const start = i * chunkSize;
+    const end = start + chunkSize;
+    const chunk = largeArray.slice(start, end);
+    result.push(chunk);
+  }
+
+  return result;
+};


### PR DESCRIPTION
### Addition(Stage 1)
- Add meeting service to fetch the meeting transcripts via the meeting room Id. The fetched speech data will be sort according to 'Created At' of the document structure (Preparation for  sending all transcripts to the azure AI)

-  Test if the front-end speech bubble original recognized text will align in the same order with the back-end 
-  Test if the Mongo will still return the same order via creation time even 3 speakers spoke in the same time.

**_Note: Need to do more tests with more raw speech in later stage(here only have 3 users and have 7 speeches in total)_**

Developing IT-41

### Testing Stage 1(Testing Pass) Test localhost:8000/api/v1/meetings/fetch-meeting-history-records
<img width="1278" alt="1" src="https://github.com/user-attachments/assets/825c66eb-d44d-4862-9882-2e040e76c16b" />
<img width="1262" alt="2" src="https://github.com/user-attachments/assets/a7d0ef77-f032-4a9a-bd55-dacbab218459" />
<img width="1254" alt="3" src="https://github.com/user-attachments/assets/63fee6d2-b551-45cd-a82b-44ea9b73eb33" />
<img width="1280" alt="4" src="https://github.com/user-attachments/assets/2508fde9-b919-4491-b63c-22512ad8129e" />
<img width="1273" alt="Screenshot 2025-06-08 031535" src="https://github.com/user-attachments/assets/4f3c4996-72dd-4f8e-80c1-d46c05087aea" />




### Addition(Stage2 Transcripts retranslation)
-A big array breaker to break the transcript into small chunks(100 max) to suit azure translator service
 -A meeting retranslation service, controller,api designed to test or may be used in the later front-end to trigger the azure translation service 
-Test the Order of the translation with front-end to see if the azure remain order as what was recognized in the front-end via POSTMAN

### Testing if the azure will return the retranslation via the order(48 long speeches test only 10 screen shots here to prove the property of  ordered translation , the original translation is in Chinese, translated all speeches in this meeting room back to English)

### Testing Stage2: localhost:8000/api/v1/meetings/history-speech-retranslation

Testing RoomId for all team members
{
    "roomId": "684454c7d79002dd299c71bd",
    "to":"en"
}

<img width="1280" alt="10" src="https://github.com/user-attachments/assets/883dd7c7-8c51-4669-a8fe-9061a5406e75" />
<img width="1280" alt="retrans2" src="https://github.com/user-attachments/assets/721bfb6a-93e3-4989-bd61-e042d6b3c369" />
<img width="1277" alt="retrans3" src="https://github.com/user-attachments/assets/e9eede80-c502-44f7-bc25-d81320d4650a" />
<img width="1268" alt="re-trans4" src="https://github.com/user-attachments/assets/f12e3358-95d6-4031-9349-8980aff29e98" />
<img width="1192" alt="re-trans5" src="https://github.com/user-attachments/assets/fb73d23e-6723-477a-9b5a-3733b8f95186" />
<img width="1268" alt="retrans6" src="https://github.com/user-attachments/assets/0cda77c0-2c7f-4339-8756-78020f6c99a9" />
<img width="1273" alt="retrans7" src="https://github.com/user-attachments/assets/61ee2001-e013-484e-9ea6-84649825e71d" />
<img width="1280" alt="retrans8" src="https://github.com/user-attachments/assets/7a953955-729f-40c9-9c79-c92f2a5cabbf" />
<img width="1274" alt="retrans9" src="https://github.com/user-attachments/assets/8a656ffb-0d96-4a56-977c-1fbf9e486f9b" />
<img width="1279" alt="showRetranslationorder1" src="https://github.com/user-attachments/assets/88207ca0-099c-4852-b1f5-e7cae2260918" />



_**Note: Maybe need to write a socket later on(need to do front-end first to test the UX) then we can make decision, IT- Update IT-41(BE)**_

Need to do API doc later on in Swagger